### PR TITLE
Fix inconsistency about bytes/codepoints by using the number of codepoints to determine how many times tha pad should be pushed.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ use std::borrow::Borrow;
 ///
 /// assert_eq!(leftpad_with("blübb", 5, ' '), "blübb");
 /// assert_eq!(leftpad_with("blübb", 3, ' '), "blübb");
+///
+/// assert_eq!(leftpad_with("čömbiñiñg märks", 22, ' '),  "  čömbiñiñg märks");
 /// ```
 pub fn leftpad_with<'a, S>(string: S, codepoints: usize, pad_char: char) -> Cow<'a, str>
     where S: Into<Cow<'a, str>>
@@ -86,6 +88,8 @@ pub fn leftpad_with<'a, S>(string: S, codepoints: usize, pad_char: char) -> Cow<
 /// assert_eq!(leftpad("blübb", 3), "blübb");
 ///
 /// assert_eq!(leftpad("blübb", 7), leftpad_with("blübb", 7, ' '));
+///
+/// assert_eq!(leftpad("čömbiñiñg märks", 22),  "  čömbiñiñg märks");
 /// ```
 pub fn leftpad<'a, S>(string: S, codepoints: usize) -> Cow<'a, str>
     where S: Into<Cow<'a, str>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,11 @@ Usage example:
 ```
 use left_pad::{leftpad, leftpad_with};
 
-assert_eq!(leftpad("blubb", 7), "  blubb");
-assert_eq!(leftpad_with("blubb", 7, '.'), "..blubb");
+assert_eq!(leftpad("blübb", 7), "  blübb");
+assert_eq!(leftpad_with("blübb", 7, '→'), "→→blübb");
 
-let s: String = "blubb".to_owned();
-assert_eq!(leftpad(s, 7), "  blubb");
+let s: String = "blübb".to_owned();
+assert_eq!(leftpad(s, 7), "  blübb");
 ```
 */
 
@@ -33,11 +33,11 @@ use std::borrow::Borrow;
 /// ```
 /// use left_pad::leftpad_with;
 ///
-/// assert_eq!(leftpad_with("blubb", 7, ' '), "  blubb");
-/// assert_eq!(leftpad_with("blubb", 7, '.'), "..blubb");
+/// assert_eq!(leftpad_with("blübb", 7, ' '), "  blübb");
+/// assert_eq!(leftpad_with("blübb", 7, '→'), "→→blübb");
 ///
-/// assert_eq!(leftpad_with("blubb", 5, ' '), "blubb");
-/// assert_eq!(leftpad_with("blubb", 3, ' '), "blubb");
+/// assert_eq!(leftpad_with("blübb", 5, ' '), "blübb");
+/// assert_eq!(leftpad_with("blübb", 3, ' '), "blübb");
 /// ```
 pub fn leftpad_with<'a, S>(string: S, codepoints: usize, pad_char: char) -> Cow<'a, str>
     where S: Into<Cow<'a, str>>
@@ -80,12 +80,12 @@ pub fn leftpad_with<'a, S>(string: S, codepoints: usize, pad_char: char) -> Cow<
 /// ```
 /// use left_pad::{leftpad,leftpad_with};
 ///
-/// assert_eq!(leftpad("blubb", 7), "  blubb");
+/// assert_eq!(leftpad("blübb", 7), "  blübb");
 ///
-/// assert_eq!(leftpad("blubb", 5), "blubb");
-/// assert_eq!(leftpad("blubb", 3), "blubb");
+/// assert_eq!(leftpad("blübb", 5), "blübb");
+/// assert_eq!(leftpad("blübb", 3), "blübb");
 ///
-/// assert_eq!(leftpad("blubb", 7), leftpad_with("blubb", 7, ' '));
+/// assert_eq!(leftpad("blübb", 7), leftpad_with("blübb", 7, ' '));
 /// ```
 pub fn leftpad<'a, S>(string: S, codepoints: usize) -> Cow<'a, str>
     where S: Into<Cow<'a, str>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,12 +46,7 @@ pub fn leftpad_with<'a, S>(string: S, codepoints: usize, pad_char: char) -> Cow<
 {
     let cow = string.into();
 
-    let cow_codepoints = {
-        let s: &str = cow.borrow();
-        s.len() - s.bytes()
-                   .filter(|b| (b >> 6) == 0b10u8 )
-                   .count()
-    };
+    let cow_codepoints = cow.chars().count();
     if codepoints <= cow_codepoints {
         return cow;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,14 +68,12 @@ pub fn leftpad_with<'a, S>(string: S, len: usize, pad_char: char) -> Cow<'a, str
 /// # Examples
 ///
 /// ```
-/// use left_pad::leftpad;
+/// use left_pad::{leftpad,leftpad_with};
 ///
 /// assert_eq!(leftpad("blubb", 7), "  blubb");
 ///
 /// assert_eq!(leftpad("blubb", 5), "blubb");
 /// assert_eq!(leftpad("blubb", 3), "blubb");
-///
-/// use left_pad::leftpad_with;
 ///
 /// assert_eq!(leftpad("blubb", 7), leftpad_with("blubb", 7, ' '));
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,12 @@ assert_eq!(leftpad(s, 7), "  blubb");
 use std::borrow::Cow;
 use std::borrow::Borrow;
 
-/// Pads a string to the given length `len` by inserting the character `pad_char` from the left.
+/// Pads a string to the given number of chars by inserting the character `pad_char` from the left.
 ///
-/// If the given string has a length longer or equal to the desired length, it will be
+/// If the given string has more than or exactly the desired number of codepoints, it will be
 /// returned as-is.
+///
+/// Codepoints are not graphemes, so the result might always not be what a human would expect.
 ///
 /// # Examples
 ///
@@ -37,16 +39,22 @@ use std::borrow::Borrow;
 /// assert_eq!(leftpad_with("blubb", 5, ' '), "blubb");
 /// assert_eq!(leftpad_with("blubb", 3, ' '), "blubb");
 /// ```
-pub fn leftpad_with<'a, S>(string: S, len: usize, pad_char: char) -> Cow<'a, str>
+pub fn leftpad_with<'a, S>(string: S, codepoints: usize, pad_char: char) -> Cow<'a, str>
     where S: Into<Cow<'a, str>>
 {
     let cow = string.into();
 
-    if !(len > cow.len()) {
+    let cow_codepoints = {
+        let s: &str = cow.borrow();
+        s.len() - s.bytes()
+                   .filter(|b| (b >> 6) == 0b10u8 )
+                   .count()
+    };
+    if codepoints <= cow_codepoints {
         return cow;
     }
 
-    let to_pad = len - cow.len();
+    let to_pad = codepoints - cow_codepoints;
     let mut padded = String::with_capacity(cow.len() + to_pad);
 
     for _ in 0..to_pad {
@@ -58,12 +66,14 @@ pub fn leftpad_with<'a, S>(string: S, len: usize, pad_char: char) -> Cow<'a, str
     padded.into()
 }
 
-/// Pads a string to the given length `len` by inserting whitespaces from the left.
+/// Pads a string to the given number of chars by inserting spaces from the left.
 ///
-/// If the given string has a length longer or equal to the desired length, it will be
+/// If the given string has more than or exactly the desired number of codepoints, it will be
 /// returned as-is.
 ///
-/// This function is equal to calling `leftpad_with(string, len, ' ')`.
+/// Codepoints are not graphemes, so the result might not always be what a human would expect.
+///
+/// This function is equal to calling `leftpad_with(string, codepoints, ' ')`.
 ///
 /// # Examples
 ///
@@ -77,8 +87,8 @@ pub fn leftpad_with<'a, S>(string: S, len: usize, pad_char: char) -> Cow<'a, str
 ///
 /// assert_eq!(leftpad("blubb", 7), leftpad_with("blubb", 7, ' '));
 /// ```
-pub fn leftpad<'a, S>(string: S, len: usize) -> Cow<'a, str>
+pub fn leftpad<'a, S>(string: S, codepoints: usize) -> Cow<'a, str>
     where S: Into<Cow<'a, str>>
 {
-    leftpad_with(string, len, ' ')
+    leftpad_with(string, codepoints, ' ')
 }


### PR DESCRIPTION
Use the number of codepoints to determine how many times tha pad should be applied.

We can't be _worse_ than the original, can we? ;)
